### PR TITLE
Fixed authentication and pub-sub cancellation

### DIFF
--- a/RedisCore/Internal/Connection.cs
+++ b/RedisCore/Internal/Connection.cs
@@ -14,6 +14,8 @@ namespace RedisCore.Internal
         private bool _connected = true;
 
         public bool Connected => _connected && _socket.Connected;
+        public bool Authenticated { get; private set; }
+
         public PipeReader Input => _pipe.Input;
         public PipeWriter Output => _pipe.Output;
 
@@ -34,5 +36,7 @@ namespace RedisCore.Internal
         }
 
         public void MarkAsDisconnected() => _connected = false;
+
+        public void MarkAsAuthenticated() => Authenticated = true;
     }
 }

--- a/RedisCore/Internal/Protocol/ProtocolHandler.cs
+++ b/RedisCore/Internal/Protocol/ProtocolHandler.cs
@@ -173,7 +173,7 @@ namespace RedisCore.Internal.Protocol
                         var totalBytesRead = 0;
                         while (totalBytesRead < strBuffer.Length)
                         {
-                            readResult = await reader.ReadAsync(cancellationToken);
+                            readResult = await reader.ReadAsync();
                             buffer = readResult.Buffer;
                             var bytesRead = (int)buffer.Length;
                             if (bytesRead == 0)
@@ -208,7 +208,7 @@ namespace RedisCore.Internal.Protocol
                             return RedisNull.Value;
                         var items = new List<RedisObject>(length);
                         for (var i = 0; i < length; ++i)
-                            items.Add(await Read(reader, cancellationToken));
+                            items.Add(await Read(reader));
                         return new RedisArray(items);
                     }
                     case '-':

--- a/RedisCore/RedisClient.cs
+++ b/RedisCore/RedisClient.cs
@@ -77,8 +77,12 @@ namespace RedisCore
             try
             {
                 var connection = await _connectionPool.Acquire();
-                if (_config.Password != null)
+                if (_config.Password != null && !connection.Authenticated)
+                {
                     await Execute(connection, new AuthCommand(_config.Password));
+                    connection.MarkAsAuthenticated();
+                }
+
                 return connection;
             }
             catch (SocketException e)

--- a/RedisCore/RedisCore.csproj
+++ b/RedisCore/RedisCore.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
     <LangVersion>latest</LangVersion>
-    <Version>0.2.2</Version>
+    <Version>0.2.3</Version>
     <PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
     <Authors>Vasiliy Novikov</Authors>
     <Description>Light .NET Core Redis client</Description>

--- a/build_template.yml
+++ b/build_template.yml
@@ -17,9 +17,9 @@ jobs:
       displayName: Install Redis
 
   - task: DotNetCoreInstaller@0
-    displayName: 'Use .NET Core SDK 2.2.102'
+    displayName: 'Use .NET Core SDK 2.2.103'
     inputs:
-      version: 2.2.102
+      version: 2.2.103
 
   - task: DotNetCoreCLI@2
     displayName: Restore


### PR DESCRIPTION
- If Redis server has enabled authentication - authenticate connection only once
- Pub-sub cancellation logic
- Updated pipeline to use the latest .NET Core SDK